### PR TITLE
Fix window check

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -46,6 +46,6 @@ export default class VueI18n {
 VueI18n.install = install;
 VueI18n.version = __VERSION__;
 
-if (typeof window && window.Vue) {
+if (typeof window !== 'undefined' && window.Vue) {
   window.Vue.use(VueI18n);
 }


### PR DESCRIPTION
`typeof` return always a not null string value. 
`typeof window` can return `"undefined"`.
```js
(!! typeof window) === true
```

(Fix vue-i18next in nuxtjs)