### PR TITLE
Prevent error when the Vue instance was not initialized with i18n

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -36,7 +36,7 @@ export function install(_Vue) {
   Vue.mixin({
     computed: {
       $t() {
-        const getKey = getByKey(this._i18nOptions, this.$i18n.i18next.options);
+        const getKey = getByKey(this._i18nOptions, this.$i18n ? this.$i18n.i18next.options : {});
 
         if (this._i18nOptions && this._i18nOptions.namespaces) {
           const { lng, namespaces } = this._i18nOptions;


### PR DESCRIPTION
This worked up to version 0.6.2
I have an application with 2 distinct Vue instances and only one of them requires the use of i18next and I am getting an error in the second instance.

Thanks