### PR TITLE
fix "cannot redefine property $i18n"

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -126,9 +126,11 @@ export function install(_Vue) {
   });
 
   // extend Vue.js
-  Object.defineProperty(Vue.prototype, '$i18n', {
-    get() { return this._i18n; },
-  });
+  if (!Object.prototype.hasOwnProperty.call(Vue, '$i18n')) {
+    Object.defineProperty(Vue.prototype, '$i18n', {
+      get() { return this._i18n; },
+    });
+  }
 
   Vue.prototype.$t = function t(key, options) {
     return this._getI18nKey(key, options);


### PR DESCRIPTION
solves [#65](https://github.com/panter/vue-i18next/issues/65)

When we have two Vue instance that uses vue-i18next in both we have a "cannot redefine property $i18n" error. 

With this fix we check before the existence of this property .

It's the same fix as the vue-i18n original repo https://github.com/kazupon/vue-i18n/issues/421 

Before :

![image](https://user-images.githubusercontent.com/25738935/53893678-eff51380-402e-11e9-8e0d-18b94f4e44f2.png)

After : 

![image](https://user-images.githubusercontent.com/25738935/53893593-c936dd00-402e-11e9-9249-e69f75ea82d2.png)

