### PR TITLE
fix(docs): Fix simple directive usage example

### DIFF
--- a/docs/guide/directive.md
+++ b/docs/guide/directive.md
@@ -27,7 +27,7 @@ const i18n = new VueI18next(i18next);
 
 // simple usage
 Vue.component("app", {
-  template: `<p v-t="hello"></p>`
+  template: `<p v-t="'hello'"></p>`
 });
 
 // full featured


### PR DESCRIPTION
The directive always expects a javascript expression. So if you want to pass a simple string, you have to enclose in an additional pairs of quotes. Otherwise the string you give is interpreted as an attribute of the current component and probably not found.