### PR TITLE
fix: component interpolation

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -45,6 +45,7 @@ export default {
           children.forEach(e => {
             if (
               !child &&
+              e.data && // Skip text nodes
               e.data.attrs &&
               e.data.attrs.place &&
               e.data.attrs.place === place

--- a/test/unit/interpolation.test.js
+++ b/test/unit/interpolation.test.js
@@ -100,6 +100,23 @@ describe('interpolation', () => {
       expect(vm.$el.outerHTML).to.equal('<div>Hello <p place="first">First Hello</p> <span place="second">test</span>.</div>');
     });
 
+    it('should interpolate components supporting text nodes', async () => {
+      const el = document.createElement('div');
+      const vm = new Vue({
+        i18n: vueI18Next,
+        render(h) {
+          return h('i18next', { ref: 'text', props: { tag: 'div', path: 'hello3' } }, [
+            h('p', { domProps: { textContent: 'First Hello' }, attrs: { place: 'first' } }),
+            ' ',
+            h('span', { domProps: { textContent: 'test' }, attrs: { place: 'second' } }),
+          ]);
+        },
+      }).$mount(el);
+
+      await nextTick();
+      expect(vm.$el.outerHTML).to.equal('<div>Hello <p place="first">First Hello</p> <span place="second">test</span>.</div>');
+    });
+
     it('should just return the children if i18next is not installed', async () => {
       const el = document.createElement('div');
       const vm = new Vue({


### PR DESCRIPTION
example in `component interpolation` not working, cause `Vue.compile` will generate a `blank text node` between `<a>` and `<strong>`.

```js
const locales = {
  en: {
    tos: "Term of Service",
    term: "I accept {{tos}}. {{promise}}.",
    promise: "I promise"
  }
};

...

Vue.component("app", {
  template: `
     <div>
      <i18next path="term" tag="label">
        <a href="#" target="_blank" place="tos">{{ $t("tos") }}</a>
        <strong place="promise">{{ $t("promise") }}</strong>
      </i18next>
    </div>`
});
```